### PR TITLE
Reduce military demand and disable US Long Distance

### DIFF
--- a/military_flights.jsonplugin
+++ b/military_flights.jsonplugin
@@ -1,6 +1,6 @@
 // Id: military_flights
 // Name: Military Flights
-// Weight: 60
+// Weight: 25
 {
     "commodityType": "passenger",
     "passengerCountMinimum": 1,

--- a/military_transfers.jsonplugin
+++ b/military_transfers.jsonplugin
@@ -1,6 +1,6 @@
 // Id: military_transfers
 // Name: Military Transfers
-// Weight: 60
+// Weight: 25
 {
     "commodityType": "passenger",
     "passengerCountMinimum": 1,

--- a/us_long_distance.jsonplugin
+++ b/us_long_distance.jsonplugin
@@ -1,6 +1,6 @@
 // Id: us_long_distance
 // Name: US Long Distance
-// Weight: 150
+// Weight: 0 [DISABLED]
 {
     "commodityType": "passenger",
     "passengerCountMinimum": 1,


### PR DESCRIPTION
Further optimizes demand generation to emphasize geoscore-driven metropolitan demand over special-case plugins.

### Changes
- **Disable US Long Distance plugin** (150 → 0 weight)
  - Conflicted with geoscore system by restricting to large US airports only
  - Removed 13% of demand generation from geographic restrictions

- **Reduce military plugins** (60 → 25 weight each, 120 → 50 total)
  - Military Flights: 60 → 25
  - Military Transfers: 60 → 25
  - Drops military from 11% to 6% of total demand

### Impact
**New demand distribution (820 total weight):**
- Metropolitan: 500 (61%) - geoscore-driven, transfer-radius compatible
- City Hopper: 100 (12%)
- Corporate: 80 (10%)
- Local: 80 (10%)
- Military: 50 (6%)
- Niche: ~10 (1%)

**Result:** 71% of demand now geoscore-weighted (up from 52%), with only 6% from military special cases. This aligns
demand generation with the geoscore system's 50nm transfer-radius mechanics, reducing artificial restrictions that
previously starved major hubs.