### PR TITLE
Remove extra comments from corp plugins

### DIFF
--- a/corporate.jsonplugin
+++ b/corporate.jsonplugin
@@ -1,8 +1,6 @@
 // Id: corporate
 // Name: Corporate Airports
 // Weight: 8
-// Uses verified business jet capable airports (79 total)
-// See Docs/CORPORATE_EXCLUSIVE_AIRPORTS.md for details
 {
     "commodityType": "passenger",
     "originIcao": [

--- a/executive_group_charter.jsonplugin
+++ b/executive_group_charter.jsonplugin
@@ -1,8 +1,6 @@
 // Id: executive_group_charter
 // Name: Executive Group Charter
 // Weight: 21
-// Uses verified business jet capable airports (79 total)
-// See Docs/CORPORATE_EXCLUSIVE_AIRPORTS.md for details
 {
     "commodityType": "passenger",
     "originIcao": [


### PR DESCRIPTION
It looks like the corp plugins aren't actually generating anything, and I have a theory it's because of these additional comment lines underneath the Weight comment.